### PR TITLE
ABFCore: Don't error out on unknown epoch types

### DIFF
--- a/src/pyabf/core.py
+++ b/src/pyabf/core.py
@@ -484,8 +484,7 @@ class ABFcore:
                 self.sweepC[position:position2] = ramp
 
             else:
-                warnings.warn(
-                    "treating unknown epoch type like a step", epochType)
+                warnings.warn("treating unknown epoch type %d like a step" % epochType)
                 self.sweepC[position:position2] = afterDelta
             position += pointCount
 


### PR DESCRIPTION
The warn method has with python 3.6 the following declaration
warnings.warn(message, category=None, stacklevel=1, source=None)
and therefore the epochType is wrong here.

Add the epoch type to the message instead.

Broken since 9bbf45bd (protocol generation, 2018-06-19).