### PR TITLE
Epochs: Warn on custom waveforms

### DIFF
--- a/src/pyabf/epochs.py
+++ b/src/pyabf/epochs.py
@@ -171,6 +171,9 @@ class Epochs:
 
         # return an empty waveform if a custom waveform file was used
         if self.abf._dacSection.nWaveformSource[self.channel] == 2:
+            warnings.warn("Custom waveforms are unsupported, using NaNs instead " +
+                          "for channel {} of sweep {}".format(self.channel,
+                          sweepNumber))
             sweepC = np.full(self.abf.sweepPointCount, np.nan)
             return sweepC
 


### PR DESCRIPTION
These are currently not supported so we also warn the user in addition
to setting the sweepC array to NaN.

I plan on adding support for reading custom waveforms from ATF files. I'll send a follow up PR once that is done.