### PR TITLE
Epochs: Support loading custom waveforms from ATF files

### DIFF
--- a/src/pyabf/__init__.py
+++ b/src/pyabf/__init__.py
@@ -11,3 +11,4 @@ from pyabf import plot
 from pyabf import calc
 from pyabf import filter
 from pyabf.abf import ABF
+from pyabf.atf_storage import ATFStorage

--- a/src/pyabf/abf.py
+++ b/src/pyabf/abf.py
@@ -14,13 +14,15 @@ if __name__ == "__main__":
     sys.path.append(os.path.dirname(__file__)+"/../")
 
 from pyabf.core import ABFcore
+from pyabf.atf_storage import ATFStorage
 
 
 class ABF(ABFcore):
-    def __init__(self, abf, preLoadData=True):
+    def __init__(self, abf, preLoadData=True, atfStorage=ATFStorage):
 
         # execute core tasks (read header and data)
         self._preLoadData = preLoadData
+        self._atfStorage = atfStorage
         self._loadEverything(abf)
 
         # perform ABF class init tasks
@@ -30,7 +32,9 @@ class ABF(ABFcore):
         self.setSweep(0)
 
     def __repr__(self):
-        return 'ABF(abf="%s", preLoadData=%s)' % (self.abfFilePath, self._preLoadData)
+        return 'ABF(abf="%s", preLoadData=%s, atfStorage=%s)' % (self.abfFilePath,
+                                                                 self._preLoadData,
+                                                                 self._atfStorage)
 
     def baseline(self, timeSec1=None, timeSec2=None):
         """

--- a/src/pyabf/atf_reader.py
+++ b/src/pyabf/atf_reader.py
@@ -1,0 +1,151 @@
+import re
+import pprint
+import numpy as np
+import os.path
+
+# File format description taken from
+# https://mdc.custhelp.com/app/answers/detail/a_id/18883/~/genepix%C2%AE-file-formats
+#
+# An ATF text file consists of records. Each line in the text file is a record.
+# Each record may consist of several fields, separated by a field separator
+# (column delimiter). The tab and comma characters are field separators. Space
+# characters around a tab or comma are ignored and considered part of the field
+# separator. Text strings are enclosed in quotation marks to ensure that any
+# embedded spaces, commas and tabs are not mistaken for field separators.
+#
+# The group of records at the beginning of the file is called the file header.
+# The file header describes the file structure and includes column titles,
+# units, and comments.
+#
+# ATF File Structure
+#  First header record 	 Format: ATF (all caps), Version number
+#  Second header record 	 Number of optional header records n,
+#   	 Number of data columns (fields) m
+#  1st optional record 	 ...
+#  2nd optional record 	 ...
+#  nth optional record
+#  (n+3)th record 	 Required record containing m fields.
+#   	 Each field contains a column title
+#  DATA RECORDS 	 Arranged in m columns (fields) of data
+
+
+class ATFReader():
+    """
+    ATFReader allows to parse ATF files from Axon.
+    """
+
+    def __init__(self, file_path):
+        """
+        Read the file in file_path and parse it as ATF.
+        """
+
+        if not os.path.isfile(file_path):
+            raise ValueError(f"The file path {file_path} does not refer to an existing file.")
+
+        with open(file_path, 'r') as fh:
+            signature, file_version = fh.readline().rstrip().split()
+
+            if signature != 'ATF':
+                raise ValueError(f"Unexpected file signature {signature}")
+
+            self._file_path = file_path
+            self._file_version = file_version
+
+            elems = fh.readline().rstrip().split()
+
+            num_optional_records = int(elems[0])
+            assert num_optional_records >= 0, "Invalid number of optional records"
+
+            num_data_columns = int(elems[1])
+
+            self._num_sweeps = num_data_columns - 1
+            assert self.num_sweeps >= 1, "Expected at least one sweep"
+
+            self._header = {}
+
+            for _ in range(num_optional_records):
+                _, key, value, _ = re.split(r'^"([^=]+)=(.*)"$', fh.readline().rstrip())
+
+                if key == "SignalsExported":
+                    self._header[key] = value.split(",")
+                elif key == "Signals":
+                    self._header[key] = re.split(r'"\t+"', value)[1:]
+                else:
+                    self._header[key] = value
+
+            def unquote(x):
+                if x[0] == '"' and x[-1] == '"':
+                    return x[1:-1]
+                else:
+                    return x
+
+            # column names with quotes removed
+            self._column_names = [unquote(x) for x in re.split(r"\t+", fh.readline().rstrip())]
+
+            data = np.genfromtxt(file_path, dtype=np.float64,
+                                 skip_header=3 + num_optional_records,
+                                 invalid_raise=True,
+                                 usecols=range(0, num_data_columns))
+
+            self._raw_data = data[:, 1:]
+            self._time = data[:, 0]
+
+            self._sampling_interval = np.mean(np.diff(self._time))
+            assert self._sampling_interval >= 0, "Invalid sampling interval"
+
+            self._num_points = len(self._time)
+            assert self._num_points >= 1, "Expected at least one point"
+
+        return
+
+    def __str__(self):
+        return ("File {file_path} using ATF version {file_version} has {num_sweeps} Sweeps, "
+                "each with {num_points} points and a sampling interval of "
+                "{sampling_interval:.6g}s\n"
+                "Column names: {column_names}\n"
+                "Optional header entries: {header}"
+                ).format(file_path=self._file_path, file_version=self._file_version,
+                         num_sweeps=self._num_sweeps, num_points=self._num_points,
+                         sampling_interval=self._sampling_interval,
+                         column_names=pprint.pformat(self._column_names),
+                         header=pprint.pformat(self._header))
+
+    @property
+    def file_version(self):
+        """Return the file version"""
+        return self._file_version
+
+    @property
+    def file_path(self):
+        """Return the file path"""
+        return self._file_path
+
+    @property
+    def num_sweeps(self):
+        """Return the number of sweeps"""
+        return self._num_sweeps
+
+    @property
+    def num_points(self):
+        """Return the number of sampling points"""
+        return self._num_points
+
+    @property
+    def header(self):
+        """Return a dictionary of all header entries"""
+        return self._header
+
+    @property
+    def sampling_interval(self):
+        """Return the sampling interval in seconds"""
+        return self._sampling_interval
+
+    @property
+    def time(self):
+        """Return the array with signal times in ms"""
+        return self._time
+
+    @property
+    def signal(self):
+        """Return the array with signal data, one column per sweep/repetition"""
+        return self._raw_data

--- a/src/pyabf/atf_storage.py
+++ b/src/pyabf/atf_storage.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import pprint
+
+from pyabf.atf_reader import ATFReader
+
+
+class ATFStorage():
+    """
+    A cache for ATFReader objects
+
+    This object can be bassed into pyABF.ABF to avoid having to repeatedly
+    reparse ATF files.
+    """
+
+    def __init__(self, basefolder=None):
+        """
+        The basefolder parameter allows to pass in a known folder location on
+        disc which holds ATF files.
+        """
+
+        self._cache = {}
+        self._basefolder = None
+
+        if basefolder != None:
+            if not os.path.isdir(basefolder):
+                raise ValueError(f"The string {basefolder} does not refer to an existing directory.")
+
+            self._basefolder = os.path.abspath(basefolder)
+
+    def _load(self, file_path):
+        """
+        The ATF file is searched in the following locations (in that order):
+          - absolute location `file_path`
+          - basefolder given in the constructor
+          - current directory
+
+        Return an ATFReader instance
+        """
+
+        # absolute path
+        location = file_path
+        if os.path.isabs(file_path):
+            try:
+                return ATFReader(file_path)
+            except ValueError:
+                pass
+
+        # basefolder
+        if self._basefolder != None:
+            basename = os.path.basename(file_path)
+            location = os.path.join(self._basefolder, basename)
+
+            try:
+                return ATFReader(location)
+            except ValueError:
+                pass
+
+        # current directory
+        location = os.path.abspath(basename)
+
+        try:
+            return ATFReader(location)
+        except ValueError:
+            pass
+
+        raise ValueError(f"Could not find the file {file_path}.")
+
+    def get(self, file_path):
+        """
+        Return the cached ATFReader instance for the given file_path or create
+        the object, cache it and return it.
+        """
+
+        if self._cache.get(file_path) == None:
+            self._cache[file_path] = self._load(file_path)
+
+        return self._cache[file_path]
+
+    def __str__(self):
+        return ("Basefolder {}\n"
+                "Cache: {}").format(self._basefolder, self._cache)


### PR DESCRIPTION
PClamp allows to describe a stimulus epoch by giving a waveform in an ATF/ABF file.

We now support reading the ATF files and return that for the stimulus in
Epoch.stimulusWaveform().

As parsing and loading the ATF files from disc takes a considerable
amount of time, the ABF class learned to use the new ATFStorage class
which caches ATF files.

The ATFStorage class also allows to load ATF files from a different
folder on disc.

Usage:

```python
 storage = pyabf.ATFStorage("../sample_data/protocols/")
 abf1 = pyabf.ABF(somefile, preloadData=True, atfStorage=storage)

 # let abf1 go out of scope

 # reuse storage class
 abf2 = pyabf.ABF(somefile, preloadData=True, atfStorage=storage)
```

I only implemented reading ATF files as that is what we are using.