### PR TITLE
abf.py: Fix ABF.dataLengthSec calculation

### DIFF
--- a/src/pyabf/abf.py
+++ b/src/pyabf/abf.py
@@ -315,9 +315,7 @@ class ABF:
                 self.sweepIntervalSec = self.sweepLengthSec
 
         # determine total ABF recording length
-        self.dataLengthSec = self.sweepIntervalSec*self.sweepCount
-        if self.sweepCount > 1:
-            self.dataLengthSec += self.sweepLengthSec
+        self.dataLengthSec = self.sweepLengthSec * self.sweepCount
         self.dataLengthMin = self.dataLengthSec / 60.0
 
         # protocol file


### PR DESCRIPTION
We don't need to take the sweep interval into account when calculating
the total data length.

In addition the old calculation was off by at least self.sweepLengthSec
as it was added once too much.