### PR TITLE
improve user list support

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,0 +1,2 @@
+# pyABF 2.3.0
+* Improved support for user lists (#110) _Thanks @haganenoneko_

--- a/dev/python/2021-06-24 user list.py
+++ b/dev/python/2021-06-24 user list.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import matplotlib.pyplot as plt
+import glob
+
+try:
+    PATH_HERE = os.path.abspath(os.path.dirname(__file__))
+    PATH_DATA = os.path.abspath(PATH_HERE+"../../../data/abfs/")
+    PATH_SRC = os.path.abspath(PATH_HERE+"../../../src/")
+    DATA_FOLDER = os.path.join(PATH_SRC, "../data/abfs/")
+    sys.path.insert(0, PATH_SRC)
+    import pyabf
+except:
+    raise EnvironmentError()
+
+
+if __name__ == "__main__":
+    for abfPath in glob.glob(DATA_FOLDER + "/*.abf"):
+        abf = pyabf.ABF(abfPath)
+        if (abf.userListEnable and abf.userListEnable[0]):
+            print(f"{abf.abfID} " +
+                  f"ParamNumber={abf.userListParamToVary} "
+                  f"ParamName={abf.userListParamToVaryName} " +
+                  f"ParamValues={abf.userList}")

--- a/tests/test_generate_headerImages.py
+++ b/tests/test_generate_headerImages.py
@@ -23,7 +23,7 @@ try:
 except:
     raise ImportError("couldn't import local pyABF")
 
-
+@pytest.mark.skip(reason="this is slow, hard to run in cloud, and does not need to be run frequently")
 def test_cookbook_createImageIndexPage():
 
     md = "# Sample ABFs\n\n"
@@ -47,7 +47,7 @@ def test_cookbook_createImageIndexPage():
     with open(PATH_PROJECT+"/data/readme.md", 'w') as f:
         f.write(md)
 
-
+@pytest.mark.skip(reason="this is slow, hard to run in cloud, and does not need to be run frequently")
 @pytest.mark.parametrize("abfPath", glob.glob("data/abfs/*.abf"))
 def test_cookbook_createHeaderImages(abfPath):
     warnings.simplefilter("ignore")

--- a/tests/test_userList.py
+++ b/tests/test_userList.py
@@ -35,3 +35,15 @@ except:
 def test_userList_values(abfPath, listValues):
     abf = pyabf.ABF(abfPath)
     assert listValues == abf.userList
+
+
+@pytest.mark.parametrize("abfPath, firstType", [
+    ("data/abfs/171117_HFMixFRET.abf", 22),
+    ("data/abfs/19212027.abf", 24),
+    ("data/abfs/user-list-durations.abf", 35),
+    ("data/abfs/2020_03_02_0000.abf", 62),
+
+])
+def test_userList_types(abfPath, firstType):
+    abf = pyabf.ABF(abfPath)
+    assert firstType == abf.userListParamToVary[0]


### PR DESCRIPTION
ABF1 files now support the user list (from fixed byte positions) although I don't have any ABF1 files with user lists to test against.

ABF2 files have improved support for user lists. ABF.userListParamToVary and ABF.userListParamToVaryName how provide additional information. Tests were added for 4 ABF2 files that use user lists.

fixes #110 

```py
abf = pyabf.ABF("user-list-durations.abf")
print(f"ParamNumber={abf.userListParamToVary}")
print(f"ParamName={abf.userListParamToVaryName}")
print(f"ParamValues={abf.userList}")
```

```
ParamNumber=[35] 
ParamName=['EPOCHINITLEVEL'] 
ParamValues=[4000.0, 6000.0, 6000.0, 10000.0, 20000.0, 30000.0, 30000.0, 30000.0, 30000.0]
```