### PR TITLE
Added necessary imports to memtest.py to solve AtributeError

### DIFF
--- a/dev/python/2021-07-09 memtest.py
+++ b/dev/python/2021-07-09 memtest.py
@@ -1,0 +1,23 @@
+import sys
+import pathlib
+
+try:
+    PATH_HERE = pathlib.Path(__file__).parent
+    PATH_ABFS = PATH_HERE.joinpath("../../data/abfs/").resolve()
+    PATH_SRC = PATH_HERE.joinpath("../../src/").resolve()
+    print(PATH_SRC)
+    sys.path.insert(0, str(PATH_SRC))
+    import pyabf
+    import pyabf.tools.memtest
+except:
+    raise EnvironmentError()
+
+
+if __name__ == "__main__":
+    abfPath = pathlib.Path(PATH_ABFS).joinpath("vc_drug_memtest.abf")
+    abf = pyabf.ABF(abfPath)
+    memtest = pyabf.tools.memtest.Memtest(abf)
+    print(f"Ih: {memtest.Ih.values}")
+    print(f"Rm: {memtest.Rm.values}")
+    print(f"Ra: {memtest.Ra.values}")
+    print(f"Cm: {memtest.CmStep.values}")

--- a/src/pyabf/tools/ap.py
+++ b/src/pyabf/tools/ap.py
@@ -1,6 +1,5 @@
 """
-Code related to detection and analysis of action potentials (APs).
-Currently it only does a really bad job, and would benefit from a recode.
+Code related to detection and measurement of action potentials (APs)
 """
 
 import warnings
@@ -18,7 +17,9 @@ sys.path.insert(0, PATH_SRC)
 logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
 
-warnings.warn("AP module is experimental (its API may change)")
+warnings.warn("The pyabf package is designed for reading ABF files (not analyzing them). " +
+              "This module is experimental, provided only for backwards compatibility, and its API may change in future releases. " +
+              "Users are encouraged to write their own ABF analysis code.")
 
 
 def _where_cross(data, threshold):

--- a/src/pyabf/tools/memtest.py
+++ b/src/pyabf/tools/memtest.py
@@ -10,6 +10,8 @@ from step protocols and ones derived from ramp protocols.
 """
 
 import pyabf
+import pyabf.tools.sweep
+import pyabf.tools.memtestMath
 import numpy as np
 import warnings
 

--- a/src/pyabf/tools/memtest.py
+++ b/src/pyabf/tools/memtest.py
@@ -7,6 +7,9 @@ Code here relates to the detection and management of cell membrane properties:
 
 This modules provides two types of membrane capacitance values: ones derived
 from step protocols and ones derived from ramp protocols.
+
+This URL has useful discussion and code for calculating membrane properties:
+https://swharden.com/blog/2020-10-11-model-neuron-ltspice
 """
 
 import pyabf
@@ -15,11 +18,21 @@ import pyabf.tools.memtestMath
 import numpy as np
 import warnings
 
-warnings.warn("Memtest module module is experimental (its API may change)")
+warnings.warn("The pyabf package is designed for reading ABF files (not analyzing them). " +
+              "This module is experimental, provided only for backwards compatibility, and its API may change in future releases. " +
+              "Users are encouraged to write their own ABF analysis code.")
 
 
 class Memtest:
-    def __init__(self, abf, channel=0):
+    def __init__(self, abf: pyabf.ABF, channel: int = 0):
+        """
+        This object contains passive cell membrane properties calculated from 
+        each sweep an episodic protocol containing a voltage-clamp step.
+
+        WARNING: These calculations are not optimized for speed or accuracy. 
+        This module is experimental and included only for backward compatibility
+        purposes. Users are highly encouraged to write their own analysis code.
+        """
         assert isinstance(abf, pyabf.ABF)
 
         self.sweepCount = abf.sweepCount

--- a/src/pyabf/tools/memtestMath.py
+++ b/src/pyabf/tools/memtestMath.py
@@ -1,14 +1,16 @@
 """
-See this page for membrane test detection theory
-https://github.com/swharden/pyABF/blob/master/docs/advanced/v1%20cookbook/memtest-simulation.ipynb
+This file contains methods which calculate passive membrane properties from
+voltage-clamp sweeps. These methods are not optimized for speed or accuracy
+and are only provided for backwards compatibility. pyabf is intended to be
+used just for reading ABF files, and users are encouraged to write their own
+python code to perform analysis of ABF data.
+
+This URL has useful discussion and code for calculating membrane properties:
+https://swharden.com/blog/2020-10-11-model-neuron-ltspice
 """
+
 import pyabf
 import numpy as np
-
-#############################################################################
-#############################################################################
-# The code below is very messy. It was hacked on a lot.
-# Refactor it later
 
 
 def _cm_ramp_points_and_voltages(abf):
@@ -95,8 +97,7 @@ def _cm_ramp_calculate(rampData, sampleRate, deltaVoltage, centerFrac=.3):
     trace2 = rampData[int(len(rampData)/2):]
     traceAvg = np.average((trace1, trace2), axis=0)
     if not len(trace1) == len(trace2):
-        log.critical("rampData length must be an even multiple of 2")
-        return
+        raise Exception("rampData length must be an even multiple of 2")
 
     # figure out the middle of the data we wish to sample from
     centerPoint = int(len(trace1))/2
@@ -241,7 +242,7 @@ def _step_calculate(abf, trace, traceStepPoint, dV=-10, stepAvgLastFrac=.2,
     Ra = ((dV*(1e-3)) / (I0*(1e-12)))*(1e-6)
     Ra = abs(Ra)
 
-    # Calculate capactance using our curve-fitted tau
+    # Calculate capacitance using our curve-fitted tau
     Cm = (tau/(Ra*(1e6)))*(1e12)
 
     return [Ih, Rm, Ra, Cm]

--- a/tests/test_memtest.py
+++ b/tests/test_memtest.py
@@ -1,0 +1,34 @@
+import pytest
+import os
+import sys
+import pathlib
+PATH_HERE = os.path.abspath(os.path.dirname(__file__))
+PATH_PROJECT = os.path.abspath(PATH_HERE+"/../")
+PATH_DATA = os.path.abspath(PATH_PROJECT+"/data/abfs/")
+PATH_HEADERS = os.path.abspath(PATH_PROJECT+"/data/headers/")
+
+try:
+    # this ensures pyABF is imported from this specific path
+    sys.path.insert(0, "src")
+    import pyabf
+    import pyabf.tools.memtest
+except:
+    raise ImportError("couldn't import local pyABF")
+
+
+def test_values_matchExpected():
+    abfPath = pathlib.Path(PATH_DATA).joinpath("vc_drug_memtest.abf")
+    abf = pyabf.ABF(abfPath)
+    memtest = pyabf.tools.memtest.Memtest(abf)
+
+    assert -6.9107 == pytest.approx(memtest.Ih.values[0], 5)
+    assert -25.4053 == pytest.approx(memtest.Ih.values[-1], 5)
+
+    assert 177.8927 == pytest.approx(memtest.Rm.values[0], 5)
+    assert 184.7151 == pytest.approx(memtest.Rm.values[-1], 5)
+
+    assert 27.9074 == pytest.approx(memtest.Ra.values[0], 5)
+    assert 38.4206 == pytest.approx(memtest.Ra.values[-1], 5)
+
+    assert 43.613 == pytest.approx(memtest.CmStep.values[0], 5)
+    assert 42.3425 == pytest.approx(memtest.CmStep.values[-1], 5)


### PR DESCRIPTION
Adding these imports in `memtest.py` can solve AttributeError, which occurs when trying to use Memtest

`import pyabf.tools.sweep`
`import pyabf.tools.memtestMath`