### PR TITLE
ABF.getOnlySweep()

### DIFF
--- a/dev/python/2024-10-15 single sweep.py
+++ b/dev/python/2024-10-15 single sweep.py
@@ -1,0 +1,29 @@
+import sys
+import pathlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+try:
+    PATH_HERE = pathlib.Path(__file__).parent
+    PATH_ABFS = PATH_HERE.joinpath("../../data/abfs/").resolve()
+    PATH_SRC = PATH_HERE.joinpath("../../src/").resolve()
+    print(PATH_SRC)
+    sys.path.insert(0, str(PATH_SRC))
+    import pyabf
+except:
+    raise EnvironmentError()
+1
+
+if __name__ == "__main__":
+    abfPath = pathlib.Path(PATH_ABFS).joinpath("14o08011_ic_pair.abf")
+
+    abf = pyabf.ABF(abfPath, loadData=False)
+    channelA = abf.getOnlySweep(sweepIndex=0, channelIndex=0)
+    channelB = abf.getOnlySweep(sweepIndex=0, channelIndex=1)
+
+    print(np.mean(channelA))
+    print(np.mean(channelB))
+
+    plt.plot(channelA)
+    plt.plot(channelB)
+    plt.show()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,5 +191,5 @@ def test_readOneSweep():
     abf = pyabf.ABF(abfPath, loadData=False)
     channelA = abf.getOnlySweep(sweepIndex=0, channelIndex=0)
     channelB = abf.getOnlySweep(sweepIndex=0, channelIndex=1)
-    assert np.mean(channelA) == -58.870506
-    assert np.mean(channelB) == -52.948666
+    assert np.mean(channelA) == pytest.approx(-58.870506, 5)
+    assert np.mean(channelB) == pytest.approx(-52.948666, 5)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -184,3 +184,12 @@ def test_headerText(abfPath):
     html = abf.headerHTML
     assert isinstance(html, str)
     assert len(html)
+
+
+def test_readOneSweep():
+    abfPath = "data/abfs/14o08011_ic_pair.abf"
+    abf = pyabf.ABF(abfPath, loadData=False)
+    channelA = abf.getOnlySweep(sweepIndex=0, channelIndex=0)
+    channelB = abf.getOnlySweep(sweepIndex=0, channelIndex=1)
+    assert np.mean(channelA) == -58.870506
+    assert np.mean(channelB) == -52.948666


### PR DESCRIPTION
Add method to read a sweep without loading the entire file into memory. Resolves #138