### PR TITLE
Add missing fSignalLowpassFilter and fSignalHighpassFilter

### DIFF
--- a/src/pyabf/abf1/headerV1.py
+++ b/src/pyabf/abf1/headerV1.py
@@ -81,6 +81,8 @@ class HeaderV1(AbfReader):
         self.fInstrumentOffset = self.readStruct("16f", 986)
         self.fSignalGain = self.readStruct("16f", 1050)
         self.fSignalOffset = self.readStruct("16f", 1114)
+        self.fSignalLowpassFilter = self.readStruct("16f", 1178)
+        self.fSignalHighpassFilter = self.readStruct("16f", 1242)
         self.sDACChannelName = self.readStruct("10s"*4, 1306)
         self.sDACChannelUnit = self.readStruct("8s"*4, 1346)
         # missing entries


### PR DESCRIPTION
These two variables from https://swharden.com/pyabf/abf1-file-format/#multi-channel-information-group-7-1044-bytes were missing in the ABF1 header.
(Sanity check: 1306-1178 = 128 bytes, corresponding to 2 arrays * 4 bytes per float * 16 floats)